### PR TITLE
スキルで生成された足場ブロックが壊せてしまう問題

### DIFF
--- a/src/com/github/unchama/player/seichiskill/passive/skywalk/SkyWalkManager.java
+++ b/src/com/github/unchama/player/seichiskill/passive/skywalk/SkyWalkManager.java
@@ -141,6 +141,7 @@ public class SkyWalkManager extends PassiveSkillManager implements Finalizable{
                 build.forEach((b) -> {
                 	b.setType(Material.AIR);
                 	b.removeMetadata("FootBlock", plugin);
+                	b.removeMetadata("Skilled", plugin);
                 });
                 build.clear();
 
@@ -170,6 +171,7 @@ public class SkyWalkManager extends PassiveSkillManager implements Finalizable{
                 	if (!b.hasMetadata("FootBlock") && Wg.canBuild(player, b) && b.getType().equals(Material.AIR)) {
                 		b.setType(footBlock);
                 		b.setMetadata("FootBlock", new FixedMetadataValue(plugin, true));
+                		b.setMetadata("Skilled", new FixedMetadataValue(plugin, true));
                 		build.add(b);
                 	}
                 });


### PR DESCRIPTION
修正簡単。足場ブロックのMetaDataに"Skilled"を付与しただけ